### PR TITLE
Only send updated and newly visible Stops/Gyms/Pokémon and not-'hidde…

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -30,7 +30,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 8
+db_schema_version = 9
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -88,20 +88,44 @@ class Pokemon(BaseModel):
     individual_stamina = IntegerField(null=True)
     move_1 = IntegerField(null=True)
     move_2 = IntegerField(null=True)
+    last_modified = DateTimeField(null=True, index=True, default=datetime.utcnow)
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_active(swLat, swLng, neLat, neLng):
-        if swLat is None or swLng is None or neLat is None or neLng is None:
-            query = (Pokemon
-                     .select()
+    def get_active(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+        query = Pokemon.select()
+        if not (swLat and swLng and neLat and neLng):
+            query = (query
                      .where(Pokemon.disappear_time > datetime.utcnow())
                      .dicts())
+        elif timestamp > 0:
+            # If timestamp is known only load modified pokemon
+            query = (query
+                     .where(((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000)) &
+                             (Pokemon.disappear_time > datetime.utcnow())) &
+                            ((Pokemon.latitude >= swLat) &
+                             (Pokemon.longitude >= swLng) &
+                             (Pokemon.latitude <= neLat) &
+                             (Pokemon.longitude <= neLng)))
+                     .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng:
+            # Send Pokemon in view but exclude those within old boundaries. Only send newly uncovered Pokemon.
+            query = (query
+                     .where(((Pokemon.disappear_time > datetime.utcnow()) &
+                            (((Pokemon.latitude >= swLat) &
+                              (Pokemon.longitude >= swLng) &
+                              (Pokemon.latitude <= neLat) &
+                              (Pokemon.longitude <= neLng))) &
+                            ~((Pokemon.disappear_time > datetime.utcnow()) &
+                              (Pokemon.latitude >= oSwLat) &
+                              (Pokemon.longitude >= oSwLng) &
+                              (Pokemon.latitude <= oNeLat) &
+                              (Pokemon.longitude <= oNeLng))))
+                     .dicts())
         else:
-            query = (Pokemon
-                     .select()
+            query = (query
                      .where((Pokemon.disappear_time > datetime.utcnow()) &
                             (((Pokemon.latitude >= swLat) &
                               (Pokemon.longitude >= swLng) &
@@ -129,7 +153,7 @@ class Pokemon(BaseModel):
 
     @staticmethod
     def get_active_by_id(ids, swLat, swLng, neLat, neLng):
-        if swLat is None or swLng is None or neLat is None or neLng is None:
+        if not (swLat and swLng and neLat and neLng):
             query = (Pokemon
                      .select()
                      .where((Pokemon.pokemon_id << ids) &
@@ -252,15 +276,35 @@ class Pokemon(BaseModel):
         return (disappear_time + 2700) % 3600
 
     @classmethod
-    def get_spawnpoints(cls, southBoundary, westBoundary, northBoundary, eastBoundary):
+    def get_spawnpoints(cls, swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
         query = Pokemon.select(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id, ((Pokemon.disappear_time.minute * 60) + Pokemon.disappear_time.second).alias('time'), fn.Count(Pokemon.spawnpoint_id).alias('count'))
 
-        if None not in (northBoundary, southBoundary, westBoundary, eastBoundary):
+        if timestamp > 0:
             query = (query
-                     .where((Pokemon.latitude <= northBoundary) &
-                            (Pokemon.latitude >= southBoundary) &
-                            (Pokemon.longitude >= westBoundary) &
-                            (Pokemon.longitude <= eastBoundary)
+                     .where(((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000))) &
+                            ((Pokemon.latitude >= swLat) &
+                             (Pokemon.longitude >= swLng) &
+                             (Pokemon.latitude <= neLat) &
+                             (Pokemon.longitude <= neLng)))
+                     .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng:
+            # Send spawnpoints in view but exclude those within old boundaries. Only send newly uncovered spawnpoints.
+            query = (query
+                     .where((((Pokemon.latitude >= swLat) &
+                              (Pokemon.longitude >= swLng) &
+                              (Pokemon.latitude <= neLat) &
+                              (Pokemon.longitude <= neLng))) &
+                            ~((Pokemon.latitude >= oSwLat) &
+                              (Pokemon.longitude >= oSwLng) &
+                              (Pokemon.latitude <= oNeLat) &
+                              (Pokemon.longitude <= oNeLng)))
+                     .dicts())
+        elif swLat and swLng and neLat and neLng:
+            query = (query
+                     .where((Pokemon.latitude <= neLat) &
+                            (Pokemon.latitude >= swLat) &
+                            (Pokemon.longitude >= swLng) &
+                            (Pokemon.longitude <= neLng)
                             ))
 
         query = query.group_by(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id, SQL('time'))
@@ -342,19 +386,64 @@ class Pokestop(BaseModel):
     last_modified = DateTimeField(index=True)
     lure_expiration = DateTimeField(null=True, index=True)
     active_fort_modifier = CharField(max_length=50, null=True)
+    last_updated = DateTimeField(null=True, index=True, default=datetime.utcnow)
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_stops(swLat, swLng, neLat, neLng):
-        if swLat is None or swLng is None or neLat is None or neLng is None:
-            query = (Pokestop
-                     .select()
+    def get_stops(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None, lured=False):
+
+        query = Pokestop.select(Pokestop.active_fort_modifier, Pokestop.enabled, Pokestop.latitude, Pokestop.longitude, Pokestop.last_modified, Pokestop.lure_expiration, Pokestop.pokestop_id)
+
+        if not (swLat and swLng and neLat and neLng):
+            query = (query
                      .dicts())
+        elif timestamp > 0:
+            query = (query
+                     .where(((Pokestop.last_updated > datetime.utcfromtimestamp(timestamp / 1000))) &
+                            (Pokestop.latitude >= swLat) &
+                            (Pokestop.longitude >= swLng) &
+                            (Pokestop.latitude <= neLat) &
+                            (Pokestop.longitude <= neLng))
+                     .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng and lured:
+            query = (query
+                     .where((((Pokestop.latitude >= swLat) &
+                              (Pokestop.longitude >= swLng) &
+                              (Pokestop.latitude <= neLat) &
+                              (Pokestop.longitude <= neLng)) &
+                             (Pokestop.active_fort_modifier.is_null(False))) &
+                            ~((Pokestop.latitude >= oSwLat) &
+                              (Pokestop.longitude >= oSwLng) &
+                              (Pokestop.latitude <= oNeLat) &
+                              (Pokestop.longitude <= oNeLng)) &
+                             (Pokestop.active_fort_modifier.is_null(False)))
+                     .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng:
+            # Send stops in view but exclude those within old boundaries. Only send newly uncovered stops.
+            query = (query
+                     .where(((Pokestop.latitude >= swLat) &
+                             (Pokestop.longitude >= swLng) &
+                             (Pokestop.latitude <= neLat) &
+                             (Pokestop.longitude <= neLng)) &
+                            ~((Pokestop.latitude >= oSwLat) &
+                              (Pokestop.longitude >= oSwLng) &
+                              (Pokestop.latitude <= oNeLat) &
+                              (Pokestop.longitude <= oNeLng)))
+                     .dicts())
+        elif lured:
+            query = (query
+                     .where(((Pokestop.last_updated > datetime.utcfromtimestamp(timestamp / 1000))) &
+                            ((Pokestop.latitude >= swLat) &
+                             (Pokestop.longitude >= swLng) &
+                             (Pokestop.latitude <= neLat) &
+                             (Pokestop.longitude <= neLng)) &
+                            (Pokestop.active_fort_modifier.is_null(False)))
+                     .dicts())
+
         else:
-            query = (Pokestop
-                     .select()
+            query = (query
                      .where((Pokestop.latitude >= swLat) &
                             (Pokestop.longitude >= swLng) &
                             (Pokestop.latitude <= neLat) &
@@ -397,11 +486,35 @@ class Gym(BaseModel):
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_gyms(swLat, swLng, neLat, neLng):
-        if swLat is None or swLng is None or neLat is None or neLng is None:
+    def get_gyms(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+        if not (swLat and swLng and neLat and neLng):
             results = (Gym
                        .select()
                        .dicts())
+        elif timestamp > 0:
+            # If timestamp is known only send last scanned Gyms.
+            results = (Gym
+                       .select()
+                       .where(((Gym.last_scanned > datetime.utcfromtimestamp(timestamp / 1000)) &
+                              (Gym.latitude >= swLat) &
+                              (Gym.longitude >= swLng) &
+                              (Gym.latitude <= neLat) &
+                              (Gym.longitude <= neLng)))
+                       .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng:
+            # Send gyms in view but exclude those within old boundaries. Only send newly uncovered gyms.
+            results = (Gym
+                       .select()
+                       .where(((Gym.latitude >= swLat) &
+                               (Gym.longitude >= swLng) &
+                               (Gym.latitude <= neLat) &
+                               (Gym.longitude <= neLng)) &
+                              ~((Gym.latitude >= oSwLat) &
+                                (Gym.longitude >= oSwLng) &
+                                (Gym.latitude <= oNeLat) &
+                                (Gym.longitude <= oNeLng)))
+                       .dicts())
+
         else:
             results = (Gym
                        .select()
@@ -461,23 +574,48 @@ class Gym(BaseModel):
 class ScannedLocation(BaseModel):
     latitude = DoubleField()
     longitude = DoubleField()
-    last_modified = DateTimeField(index=True)
+    last_modified = DateTimeField(index=True, default=datetime.utcnow)
 
     class Meta:
         primary_key = CompositeKey('latitude', 'longitude')
 
     @staticmethod
-    def get_recent(swLat, swLng, neLat, neLng):
-        query = (ScannedLocation
-                 .select()
-                 .where((ScannedLocation.last_modified >=
-                        (datetime.utcnow() - timedelta(minutes=15))) &
-                        (ScannedLocation.latitude >= swLat) &
-                        (ScannedLocation.longitude >= swLng) &
-                        (ScannedLocation.latitude <= neLat) &
-                        (ScannedLocation.longitude <= neLng))
-                 .order_by(ScannedLocation.last_modified.asc())
-                 .dicts())
+    def get_recent(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+        activeTime = (datetime.utcnow() - timedelta(minutes=15))
+        if timestamp > 0:
+            query = (ScannedLocation
+                     .select()
+                     .where(((ScannedLocation.last_modified >= datetime.utcfromtimestamp(timestamp / 1000))) &
+                            (ScannedLocation.latitude >= swLat) &
+                            (ScannedLocation.longitude >= swLng) &
+                            (ScannedLocation.latitude <= neLat) &
+                            (ScannedLocation.longitude <= neLng))
+                     .dicts())
+        elif oSwLat and oSwLng and oNeLat and oNeLng:
+            # Send scannedlocations in view but exclude those within old boundaries. Only send newly uncovered scannedlocations.
+            query = (ScannedLocation
+                     .select()
+                     .where((((ScannedLocation.last_modified >= activeTime)) &
+                             (ScannedLocation.latitude >= swLat) &
+                             (ScannedLocation.longitude >= swLng) &
+                             (ScannedLocation.latitude <= neLat) &
+                             (ScannedLocation.longitude <= neLng)) &
+                            ~(((ScannedLocation.last_modified >= activeTime)) &
+                              (ScannedLocation.latitude >= oSwLat) &
+                              (ScannedLocation.longitude >= oSwLng) &
+                              (ScannedLocation.latitude <= oNeLat) &
+                              (ScannedLocation.longitude <= oNeLng)))
+                     .dicts())
+        else:
+            query = (ScannedLocation
+                     .select()
+                     .where((ScannedLocation.last_modified >= activeTime) &
+                            (ScannedLocation.latitude >= swLat) &
+                            (ScannedLocation.longitude >= swLng) &
+                            (ScannedLocation.latitude <= neLat) &
+                            (ScannedLocation.longitude <= neLng))
+                     .order_by(ScannedLocation.last_modified.asc())
+                     .dicts())
 
         return list(query)
 
@@ -617,69 +755,98 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
     pokestops = {}
     gyms = {}
     skipped = 0
-    encountered_pokemon = []
+    stopsskipped = 0
+    forts = None
+    wild_pokemon = None
+    pokesfound = False
+    fortsfound = False
 
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
         if config['parse_pokemon']:
-            # pre-build a list of encountered pokemon
-            encounter_ids = [b64encode(str(p['encounter_id'])) for p in cell.get('wild_pokemons', [])]
-            if encounter_ids:
-                query = (Pokemon
-                         .select()
-                         .where((Pokemon.disappear_time > datetime.utcnow()) & (Pokemon.encounter_id << encounter_ids))
-                         .dicts()
-                         )
-                encountered_pokemon = [(p['encounter_id'], p['spawnpoint_id']) for p in query]
-
-            for p in cell.get('wild_pokemons', []):
-                # Don't parse pokemon we've already encountered. Avoids IVs getting nulled out on rescanning.
-                if (b64encode(str(p['encounter_id'])), p['spawn_point_id']) in encountered_pokemon:
-                    skipped += 1
-                    continue
-
-                # time_till_hidden_ms was overflowing causing a negative integer.
-                # It was also returning a value above 3.6M ms.
-                if 0 < p['time_till_hidden_ms'] < 3600000:
-                    d_t = datetime.utcfromtimestamp(
-                        (p['last_modified_timestamp_ms'] +
-                         p['time_till_hidden_ms']) / 1000.0)
+            if len(cell.get('wild_pokemons', [])) > 0:
+                pokesfound = True
+                if wild_pokemon is None:
+                    wild_pokemon = cell.get('wild_pokemons', [])
                 else:
-                    # Set a value of 15 minutes because currently its unknown but larger than 15.
-                    d_t = datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + 900000) / 1000.0)
+                    wild_pokemon += cell.get('wild_pokemons', [])
 
-                printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
-                             p['longitude'], d_t)
+        if config['parse_pokestops'] or config['parse_gyms']:
+            if len(cell.get('forts', [])) > 0:
+                fortsfound = True
+                if forts is None:
+                    forts = cell.get('forts', [])
+                else:
+                    forts += cell.get('forts', [])
 
-                # Scan for IVs and moves
-                encounter_result = None
-                if (args.encounter and (p['pokemon_data']['pokemon_id'] in args.encounter_whitelist or
-                                        p['pokemon_data']['pokemon_id'] not in args.encounter_blacklist and not args.encounter_whitelist)):
-                    time.sleep(args.encounter_delay)
-                    encounter_result = api.encounter(encounter_id=p['encounter_id'],
-                                                     spawn_point_id=p['spawn_point_id'],
-                                                     player_latitude=step_location[0],
-                                                     player_longitude=step_location[1])
-                construct_pokemon_dict(pokemons, p, encounter_result, d_t)
+    if pokesfound:
+        encounter_ids = [b64encode(str(p['encounter_id'])) for p in wild_pokemon]
+        # For all the wild pokemon we found check if an active pokemon is in the database
+        query = (Pokemon
+                 .select(Pokemon.encounter_id, Pokemon.spawnpoint_id)
+                 .where((Pokemon.disappear_time > datetime.utcnow()) & (Pokemon.encounter_id << encounter_ids))
+                 .dicts())
 
-                if args.webhooks:
-                    wh_update_queue.put(('pokemon', {
-                        'encounter_id': b64encode(str(p['encounter_id'])),
-                        'spawnpoint_id': p['spawn_point_id'],
-                        'pokemon_id': p['pokemon_data']['pokemon_id'],
-                        'latitude': p['latitude'],
-                        'longitude': p['longitude'],
-                        'disappear_time': calendar.timegm(d_t.timetuple()),
-                        'last_modified_time': p['last_modified_timestamp_ms'],
-                        'time_until_hidden_ms': p['time_till_hidden_ms'],
-                        'individual_attack': pokemons[p['encounter_id']]['individual_attack'],
-                        'individual_defense': pokemons[p['encounter_id']]['individual_defense'],
-                        'individual_stamina': pokemons[p['encounter_id']]['individual_stamina'],
-                        'move_1': pokemons[p['encounter_id']]['move_1'],
-                        'move_2': pokemons[p['encounter_id']]['move_2']
-                    }))
+        # Store all encounter_ids and spawnpoint_id for the pokemon in query (all thats needed to make sure its unique)
+        encountered_pokemon = [(p['encounter_id'], p['spawnpoint_id']) for p in query]
 
-        for f in cell.get('forts', []):
+        for p in wild_pokemon:
+            if (b64encode(str(p['encounter_id'])), p['spawn_point_id']) in encountered_pokemon:
+                # If pokemon has been encountered before dont process it.
+                skipped += 1
+                continue
+
+            # time_till_hidden_ms was overflowing causing a negative integer.
+            # It was also returning a value above 3.6M ms.
+            if 0 < p['time_till_hidden_ms'] < 3600000:
+                d_t = datetime.utcfromtimestamp(
+                    (p['last_modified_timestamp_ms'] +
+                     p['time_till_hidden_ms']) / 1000.0)
+            else:
+                # Set a value of 15 minutes because currently its unknown but larger than 15.
+                d_t = datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + 900000) / 1000.0)
+
+            printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
+                         p['longitude'], d_t)
+
+            # Scan for IVs and moves
+            encounter_result = None
+            if (args.encounter and (p['pokemon_data']['pokemon_id'] in args.encounter_whitelist or
+                                    p['pokemon_data']['pokemon_id'] not in args.encounter_blacklist and not args.encounter_whitelist)):
+                time.sleep(args.encounter_delay)
+                encounter_result = api.encounter(encounter_id=p['encounter_id'],
+                                                 spawn_point_id=p['spawn_point_id'],
+                                                 player_latitude=step_location[0],
+                                                 player_longitude=step_location[1])
+            construct_pokemon_dict(pokemons, p, encounter_result, d_t)
+            if args.webhooks:
+                wh_update_queue.put(('pokemon', {
+                    'encounter_id': b64encode(str(p['encounter_id'])),
+                    'spawnpoint_id': p['spawn_point_id'],
+                    'pokemon_id': p['pokemon_data']['pokemon_id'],
+                    'latitude': p['latitude'],
+                    'longitude': p['longitude'],
+                    'disappear_time': calendar.timegm(d_t.timetuple()),
+                    'last_modified_time': p['last_modified_timestamp_ms'],
+                    'time_until_hidden_ms': p['time_till_hidden_ms'],
+                    'individual_attack': pokemons[p['encounter_id']]['individual_attack'],
+                    'individual_defense': pokemons[p['encounter_id']]['individual_defense'],
+                    'individual_stamina': pokemons[p['encounter_id']]['individual_stamina'],
+                    'move_1': pokemons[p['encounter_id']]['move_1'],
+                    'move_2': pokemons[p['encounter_id']]['move_2']
+                }))
+
+    if fortsfound:
+        if config['parse_pokestops']:
+            stop_ids = [f['id'] for f in forts if f.get('type') == 1]
+            if len(stop_ids) > 0:
+                query = (Pokestop
+                         .select(Pokestop.pokestop_id, Pokestop.last_modified)
+                         .where((Pokestop.pokestop_id << stop_ids))
+                         .dicts())
+                encountered_pokestops = [(f['pokestop_id'], int((f['last_modified'] - datetime(1970, 1, 1)).total_seconds())) for f in query]
+
+        for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops
                 if 'active_fort_modifier' in f:
                     lure_expiration = datetime.utcfromtimestamp(
@@ -697,17 +864,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         }))
                 else:
                     lure_expiration, active_fort_modifier = None, None
-
-                pokestops[f['id']] = {
-                    'pokestop_id': f['id'],
-                    'enabled': f['enabled'],
-                    'latitude': f['latitude'],
-                    'longitude': f['longitude'],
-                    'last_modified': datetime.utcfromtimestamp(
-                        f['last_modified_timestamp_ms'] / 1000.0),
-                    'lure_expiration': lure_expiration,
-                    'active_fort_modifier': active_fort_modifier
-                }
 
                 # Send all pokéstops to webhooks
                 if args.webhooks and not args.webhook_updates_only:
@@ -728,19 +884,23 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         'active_fort_modifier': active_fort_modifier
                     }))
 
-            elif config['parse_gyms'] and f.get('type') is None:  # Currently, there are only stops and gyms
-                gyms[f['id']] = {
-                    'gym_id': f['id'],
-                    'team_id': f.get('owned_by_team', 0),
-                    'guard_pokemon_id': f.get('guard_pokemon_id', 0),
-                    'gym_points': f.get('gym_points', 0),
+                if (f['id'], int(f['last_modified_timestamp_ms'] / 1000.0)) in encountered_pokestops:
+                    # If pokestop has been encountered before and hasn't changed dont process it.
+                    stopsskipped += 1
+                    continue
+
+                pokestops[f['id']] = {
+                    'pokestop_id': f['id'],
                     'enabled': f['enabled'],
                     'latitude': f['latitude'],
                     'longitude': f['longitude'],
                     'last_modified': datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0),
+                    'lure_expiration': lure_expiration,
+                    'active_fort_modifier': active_fort_modifier
                 }
 
+            elif config['parse_gyms'] and f.get('type') is None:  # Currently, there are only stops and gyms
                 # Send gyms to webhooks
                 if args.webhooks and not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
@@ -756,6 +916,18 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         'last_modified': calendar.timegm(gyms[f['id']]['last_modified'].timetuple())
                     }))
 
+                gyms[f['id']] = {
+                    'gym_id': f['id'],
+                    'team_id': f.get('owned_by_team', 0),
+                    'guard_pokemon_id': f.get('guard_pokemon_id', 0),
+                    'gym_points': f.get('gym_points', 0),
+                    'enabled': f['enabled'],
+                    'latitude': f['latitude'],
+                    'longitude': f['longitude'],
+                    'last_modified': datetime.utcfromtimestamp(
+                        f['last_modified_timestamp_ms'] / 1000.0),
+                }
+
     if len(pokemons):
         db_update_queue.put((Pokemon, pokemons))
     if len(pokestops):
@@ -763,19 +935,22 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
     if len(gyms):
         db_update_queue.put((Gym, gyms))
 
-    log.info('Parsing found %d pokemons, %d pokestops, and %d gyms',
+    log.info('Parsing found %d pokemons, %d pokestops, and %d gyms.',
              len(pokemons) + skipped,
-             len(pokestops),
+             len(pokestops) + stopsskipped,
              len(gyms))
+
+    log.debug('Skipped %d Pokemons and %d pokestops.',
+              skipped,
+              stopsskipped)
 
     db_update_queue.put((ScannedLocation, {0: {
         'latitude': step_location[0],
         'longitude': step_location[1],
-        'last_modified': datetime.utcnow()
     }}))
 
     return {
-        'count': len(pokemons) + skipped + len(pokestops) + len(gyms),
+        'count': skipped + stopsskipped + len(pokemons) + len(pokestops) + len(gyms),
         'gyms': gyms,
     }
 
@@ -951,7 +1126,7 @@ def clean_db_loop(args):
 
             # Remove active modifier from expired lured pokestops
             query = (Pokestop
-                     .update(lure_expiration=None)
+                     .update(lure_expiration=None, active_fort_modifier=None)
                      .where(Pokestop.lure_expiration < datetime.utcnow()))
             query.execute()
 
@@ -1087,4 +1262,10 @@ def database_migrate(db, old_ver):
             migrator.add_column('pokemon', 'individual_stamina', IntegerField(null=True, default=0)),
             migrator.add_column('pokemon', 'move_1', IntegerField(null=True, default=0)),
             migrator.add_column('pokemon', 'move_2', IntegerField(null=True, default=0))
+        )
+
+    if old_ver < 9:
+        migrate(
+            migrator.add_column('pokemon', 'last_modified', DateTimeField(null=True, index=True)),
+            migrator.add_column('pokestop', 'last_updated', DateTimeField(null=True, index=True))
         )

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -22,10 +22,16 @@ var languageLookupThreshold = 3
 
 var searchMarkerStyles
 
+var timestamp
 var excludedPokemon = []
 var notifiedPokemon = []
 var notifiedRarity = []
 var notifiedMinPerfection = null
+
+var buffer = []
+var reincludedPokemon = []
+var reids = []
+
 
 var map
 var rawDataIsLoading = false
@@ -35,6 +41,17 @@ var searchMarker
 var storeZoom = true
 var scanPath
 var moves
+
+var oSwLat
+var oSwLng
+var oNeLat
+var oNeLng
+
+var lastpokestops
+var lastgyms
+var lastpokemon
+var lastslocs
+var lastspawns
 
 var selectedStyle = 'light'
 
@@ -55,6 +72,7 @@ function excludePokemon (id) { // eslint-disable-line no-unused-vars
     $selectExclude.val().concat(id)
   ).trigger('change')
 }
+
 
 function notifyAboutPokemon (id) { // eslint-disable-line no-unused-vars
   $selectPokemonNotify.val(
@@ -914,6 +932,7 @@ function loadRawData () {
   var loadPokestops = Store.get('showPokestops')
   var loadScanned = Store.get('showScanned')
   var loadSpawnpoints = Store.get('showSpawnpoints')
+  var loadLuredOnly = Boolean(Store.get('showLuredPokestopsOnly'))
 
   var bounds = map.getBounds()
   var swPoint = bounds.getSouthWest()
@@ -927,15 +946,28 @@ function loadRawData () {
     url: 'raw_data',
     type: 'GET',
     data: {
+      'timestamp': timestamp,
       'pokemon': loadPokemon,
+      'lastpokemon': lastpokemon,
       'pokestops': loadPokestops,
+      'lastpokestops': lastpokestops,
+      'luredonly': loadLuredOnly,
       'gyms': loadGyms,
+      'lastgyms': lastgyms,
       'scanned': loadScanned,
+      'lastslocs': lastslocs,
       'spawnpoints': loadSpawnpoints,
+      'lastspawns': lastspawns,
       'swLat': swLat,
       'swLng': swLng,
       'neLat': neLat,
-      'neLng': neLng
+      'neLng': neLng,
+      'oSwLat': oSwLat,
+      'oSwLng': oSwLng,
+      'oNeLat': oNeLat,
+      'oNeLng': oNeLng,
+      'reids': String(reincludedPokemon),
+      'eids': String(excludedPokemon)
     },
     dataType: 'json',
     cache: false,
@@ -958,7 +990,7 @@ function processPokemons (i, item) {
   }
 
   if (!(item['encounter_id'] in mapData.pokemons) &&
-    excludedPokemon.indexOf(item['pokemon_id']) < 0) {
+    excludedPokemon.indexOf(item['pokemon_id']) < 0 && item['disappear_time'] > Date.now()) {
     // add marker to map and item to dict
     if (item.marker) {
       item.marker.setMap(null)
@@ -977,18 +1009,10 @@ function processPokestops (i, item) {
   }
 
   if (Store.get('showLuredPokestopsOnly') && !item['lure_expiration']) {
-    if (mapData.pokestops[item['pokestop_id']] && mapData.pokestops[item['pokestop_id']].marker) {
-      if (mapData.pokestops[item['pokestop_id']].marker.rangeCircle) {
-        mapData.pokestops[item['pokestop_id']].marker.rangeCircle.setMap(null)
-      }
-      mapData.pokestops[item['pokestop_id']].marker.setMap(null)
-      delete mapData.pokestops[item['pokestop_id']]
-    }
     return true
   }
 
-  if (!mapData.pokestops[item['pokestop_id']]) { // add marker to map and item to dict
-    // add marker to map and item to dict
+  if (!mapData.pokestops[item['pokestop_id']]) { // new pokestop, add marker to map and item to dict
     if (item.marker && item.marker.rangeCircle) {
       item.marker.rangeCircle.setMap(null)
     }
@@ -997,7 +1021,7 @@ function processPokestops (i, item) {
     }
     item.marker = setupPokestopMarker(item)
     mapData.pokestops[item['pokestop_id']] = item
-  } else {
+  } else {  // change existing pokestop marker to unlured/lured
     var item2 = mapData.pokestops[item['pokestop_id']]
     if (!!item['lure_expiration'] !== !!item2['lure_expiration']) {
       if (item2.marker && item2.marker.rangeCircle) {
@@ -1007,6 +1031,45 @@ function processPokestops (i, item) {
       item.marker = setupPokestopMarker(item)
       mapData.pokestops[item['pokestop_id']] = item
     }
+  }
+}
+
+function updatePokestops () {
+  if (!Store.get('showPokestops')) {
+    return false
+  }
+
+  var removeStops = []
+  var currentTime = new Date().getTime()
+
+  // change lured pokestop marker to unlured when expired
+  $.each(mapData.pokestops, function (key, value) {
+    if (value['lure_expiration'] && value['lure_expiration'] < currentTime) {
+      value['lure_expiration'] = null
+      if (value.marker && value.marker.rangeCircle) {
+        value.marker.rangeCircle.setMap(null)
+      }
+      value.marker.setMap(null)
+      value.marker = setupPokestopMarker(value)
+    }
+  })
+
+  // remove unlured stops if show lured only is selected
+  if (Store.get('showLuredPokestopsOnly')) {
+    $.each(mapData.pokestops, function (key, value) {
+      if (!value['lure_expiration']) {
+        removeStops.push(key)
+      }
+    })
+    $.each(removeStops, function (key, value) {
+      if (mapData.pokestops[value] && mapData.pokestops[value].marker) {
+        if (mapData.pokestops[value].marker.rangeCircle) {
+          mapData.pokestops[value].marker.rangeCircle.setMap(null)
+        }
+        mapData.pokestops[value].marker.setMap(null)
+        delete mapData.pokestops[value]
+      }
+    })
   }
 }
 
@@ -1030,11 +1093,7 @@ function processScanned (i, item) {
 
   var scanId = item['latitude'] + '|' + item['longitude']
 
-  if (scanId in mapData.scanned) {
-    mapData.scanned[scanId].marker.setOptions({
-      fillColor: getColorByDate(item['last_modified'])
-    })
-  } else { // add marker to map and item to dict
+  if (!(scanId in mapData.scanned)) { // add marker to map and item to dict
     if (item.marker) {
       item.marker.setMap(null)
     }
@@ -1043,25 +1102,50 @@ function processScanned (i, item) {
   }
 }
 
+function updateScanned () {
+  if (!Store.get('showScanned')) {
+    return false
+  }
+
+  $.each(mapData.scanned, function (key, value) {
+    if (map.getBounds().intersects(value.marker.getBounds())) {
+      value.marker.setOptions({
+        fillColor: getColorByDate(value['last_modified'])
+      })
+    }
+  })
+}
+
 function processSpawnpoints (i, item) {
   if (!Store.get('showSpawnpoints')) {
     return false
   }
 
   var id = item['spawnpoint_id']
-  var zoom = map.getZoom()
 
-  if (id in mapData.spawnpoints) {
-    var hue = getColorBySpawnTime(item['time'])
-    mapData.spawnpoints[id].marker.setIcon(changeSpawnIcon(hue, zoom))
-    mapData.spawnpoints[id].marker.setZIndex(spawnPointIndex(hue))
-  } else { // add marker to map and item to dict
+  if (!(id in mapData.spawnpoints)) { // add marker to map and item to dict
     if (item.marker) {
       item.marker.setMap(null)
     }
     item.marker = setupSpawnpointMarker(item)
     mapData.spawnpoints[id] = item
   }
+}
+
+function updateSpawnPoints () {
+  if (!Store.get('showSpawnpoints')) {
+    return false
+  }
+
+  var zoom = map.getZoom()
+
+  $.each(mapData.spawnpoints, function (key, value) {
+    if (map.getBounds().contains(value.marker.getPosition())) {
+      var hue = getColorBySpawnTime(value['time'])
+      value.marker.setIcon(changeSpawnIcon(hue, zoom))
+      value.marker.setZIndex(spawnPointIndex(hue))
+    }
+  })
 }
 
 function updateMap () {
@@ -1079,9 +1163,31 @@ function updateMap () {
     showInBoundsMarkers(mapData.spawnpoints, 'inbound')
 //    drawScanPath(result.scanned);
     clearStaleMarkers()
+
+    updateScanned()
+    updateSpawnPoints()
+    updatePokestops()
+
     if ($('#stats').hasClass('visible')) {
       countMarkers(map)
     }
+
+    oSwLat = result.oSwLat
+    oSwLng = result.oSwLng
+    oNeLat = result.oNeLat
+    oNeLng = result.oNeLng
+
+    lastgyms = result.lastgyms
+    lastpokestops = result.lastpokestops
+    lastpokemon = result.lastpokemon
+    lastslocs = result.lastslocs
+    lastspawns = result.lastspawns
+
+    reids = result.reids
+    if (reids instanceof Array) {
+      reincludedPokemon = reids.filter(function (e) { return this.indexOf(e) < 0 }, reincludedPokemon)
+    }
+    timestamp = result.timestamp
     lastUpdateTime = Date.now()
   })
 }
@@ -1425,6 +1531,7 @@ $(function () {
 
   $selectLuredPokestopsOnly.on('change', function () {
     Store.set('showLuredPokestopsOnly', this.value)
+    lastpokestops = false
     updateMap()
   })
 
@@ -1556,7 +1663,10 @@ $(function () {
 
     // setup list change behavior now that we have the list to work from
     $selectExclude.on('change', function (e) {
+      buffer = excludedPokemon
       excludedPokemon = $selectExclude.val().map(Number)
+      buffer = buffer.filter(function (e) { return this.indexOf(e) < 0 }, excludedPokemon)
+      reincludedPokemon = reincludedPokemon.concat(buffer)
       clearStaleMarkers()
       Store.set('remember_select_exclude', excludedPokemon)
     })
@@ -1603,6 +1713,20 @@ $(function () {
     return function () {
       Store.set(storageKey, this.checked)
       if (this.checked) {
+        // When switch is turned on we asume it has been off, makes sure we dont end up in limbo
+        // Without this there could've been a situation where no markers are on map and only newly modified ones are loaded
+        if (storageKey === 'showPokemon') {
+          lastpokemon = false
+        } else if (storageKey === 'showGyms') {
+          lastgyms = false
+        } else if (storageKey === 'showPokestops') {
+          lastpokestops = false
+        } else if (storageKey === 'showScanned') {
+          lastslocs = false
+        } else if (storageKey === 'showSpawnpoints') {
+          lastspawns = false
+        }
+
         updateMap()
       } else {
         $.each(dataType, function (d, dType) {
@@ -1624,10 +1748,18 @@ $(function () {
   }
 
   // Setup UI element interactions
-  $('#gyms-switch').change(buildSwitchChangeListener(mapData, ['gyms'], 'showGyms'))
-  $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon'))
-  $('#scanned-switch').change(buildSwitchChangeListener(mapData, ['scanned'], 'showScanned'))
-  $('#spawnpoints-switch').change(buildSwitchChangeListener(mapData, ['spawnpoints'], 'showSpawnpoints'))
+  $('#gyms-switch').change(function () {
+    buildSwitchChangeListener(mapData, ['gyms'], 'showGyms').bind(this)()
+  })
+  $('#pokemon-switch').change(function () {
+    buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon').bind(this)()
+  })
+  $('#scanned-switch').change(function () {
+    buildSwitchChangeListener(mapData, ['scanned'], 'showScanned').bind(this)()
+  })
+  $('#spawnpoints-switch').change(function () {
+    buildSwitchChangeListener(mapData, ['spawnpoints'], 'showSpawnpoints').bind(this)()
+  })
   $('#ranges-switch').change(buildSwitchChangeListener(mapData, ['gyms', 'pokemons', 'pokestops'], 'showRanges'))
 
   $('#pokestops-switch').change(function () {
@@ -1636,8 +1768,10 @@ $(function () {
     }
     var wrapper = $('#lured-pokestops-only-wrapper')
     if (this.checked) {
+      lastpokestops = false
       wrapper.show(options)
     } else {
+      lastpokestops = false
       wrapper.hide(options)
     }
     return buildSwitchChangeListener(mapData, ['pokestops'], 'showPokestops').bind(this)()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->

<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->

<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

…n' Pokémon in the JSON from server to client. (#1303)
- Only send 'not-hidden' pokemon
- Forgot to take out console.log
- More space fixes
- Bye redundant pokestop requests. Hi, travis?
- <3 Travis
- one more commit, should really test before push
- When moving screen only send new pokestops + modified
- Yes, spaces indentations and empty lines..
- And again..
- And another..
- Dont query each ID but remove ID's we dont send afterwards.
- Check if Stops/Gyms go from off to on, use same old/previous coords for both Gyms/Stops and use optional parameters in get_stops/get_gyms instead of new function
- Spaces indents and you know whats.
- Only send updated and newly visible Stops/Gyms and not-'hidden' Pokemon.
- Query datetime instead of time
- Clean exclude query.
- over-indented
- Only send modified pokemon and uncovered.
- Fix list + list, instead of .update
- Default value for last_modified
- Optimize SQL queries
- Code cleanup
- Code from PR #1272, Pokémon already in database don't need to be parsed again.
- Code fixes and optimising ScannedLocations
- Fix if clause so pokemen get properly skipped.
- A bridge too far, ScannedLocations dont update properly when only sending new locations (Reverting Scannedlocations changes)
- Code fixes
- Check for Gym last scanned instead of modified to update front-end Last Scanned value.
- Code cleanup/optimization for app.py
- refactor map.js to not require full data set for scanned locations and spawn points
- Fix switch flip in between json updates
- Optimize scannedlocations and spawnpoints
- Random capitals and code fixes
- Optimize map.js thanks @DiscoTim
- Fix class so it works like it used to
- Code clean up, prevstamp was not used
- When zooming in we are not uncovering new terrain, so no need to look further then last_modified
- # Comments to clarify
- It needs some overlap
- Determine last_modified on insert
- Move timestanp generation up
- Reduced the need for backtrack on timestamp

Reduced the default response, no need for the previous status on switch if its false.

Dont send the new fields in the response

Collect all pokemon/forts from cells before running queries.

Dont upsert pokestops that haven't changed since last scan.

Show in log how many pokemon/pokestop we didnt upsert (skipped).

Set scannedlocation last_modified on upsert instead of in code.

Add extra column on pokestops to keep track of when its been updated so we can send it to the map.
- update map.js to not require full set of pokestops
- Minor text fixes
- Frontend/Backend fixes

Only send lured stops if lured-only is selected

Resend unhidden Pokes
- Minor map fix
- Minor text fixes.
- Send all pokemon details to frontend
- Small woopsie

oh baby, oh baby, prepare for disappointment ;P -Thunderfox
